### PR TITLE
Continue working on event API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,169 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "com-api"
 version = "0.1.0"
+dependencies = [
+ "futures",
+]
 
 [[package]]
 name = "com-api-example"
 version = "0.1.0"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/com-api/Cargo.toml
+++ b/com-api/Cargo.toml
@@ -6,3 +6,6 @@ publish = ["common"]
 license = "Apache-2.0"
 
 [dependencies]
+
+[dev-dependencies]
+futures = { version = "0.3", features = ["executor"] }

--- a/com-api/src/lib.rs
+++ b/com-api/src/lib.rs
@@ -42,11 +42,9 @@
 
 use crate::sample_impl::{Publisher, Subscriber};
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
-use std::process::Output;
 
 #[derive(Debug)]
 pub enum Error {
@@ -66,6 +64,8 @@ pub trait Builder {
 pub trait Runtime {
     type InstanceSpecifier;
 
+    // TBD: HOW?!?
+    /*
     type Instance<I>: Instance<I>
     where
         I: Interface;
@@ -73,7 +73,7 @@ pub trait Runtime {
     fn make_instance<I: Interface>(
         &self,
         instance_specifier: Self::InstanceSpecifier,
-    ) -> Self::Instance<I>;
+    ) -> Self::Instance<I>;*/
 }
 
 pub trait RuntimeBuilder: Builder
@@ -157,7 +157,7 @@ where
     unsafe fn assume_init(self) -> Self::SampleMut;
 }
 
-struct InstanceSpecifier {}
+pub struct InstanceSpecifier {}
 
 // interface Auto {
 //     linkes_rad: Event<Rad>,
@@ -169,8 +169,8 @@ struct Rad {}
 
 struct Auspuff {}
 
-trait ProducerBuilder: Builder {}
-trait ConsumerBuilder: Builder {}
+pub trait ProducerBuilder: Builder {}
+pub trait ConsumerBuilder: Builder {}
 
 pub trait Interface {}
 
@@ -269,8 +269,8 @@ mod test {
         let runtime = runtime_builder.build().unwrap();
         let builder = runtime.make_instance::<AutoInterface>(InstanceSpecifier {});
         //.key_str("key", "value");
-        let producer = builder.producer().build().unwrap();
-        let consumer = builder.consumer().build().unwrap();
+        let _producer = builder.producer().build().unwrap();
+        let _consumer = builder.consumer().build().unwrap();
     }
 
     #[test]

--- a/com-api/src/sample_impl.rs
+++ b/com-api/src/sample_impl.rs
@@ -11,73 +11,21 @@
 
 #![allow(dead_code)]
 
-use crate::{
-    Builder, ConsumerBuilder, Instance, InstanceSpecifier, Interface, ProducerBuilder, Reloc,
-    SampleInstance,
-};
+use crate::{Builder, Instance, InstanceSpecifier, Interface, Reloc, SampleInstance};
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::time::Duration;
 
-pub struct DefaultInstance<I: Interface> {
-    instance_id: InstanceSpecifier,
-    _phantom_data: PhantomData<I>,
-}
-
-/*impl<I: Interface> Instance<I> for DefaultInstance<I> {
-    fn instance_id(&self) -> &InstanceSpecifier {
-        &self.instance_id
-    }
-
-    fn producer(&self) -> crate::Result<<I as Interface>::Producer> {
-        Ok(<I as Interface>::producer(&self.instance_id))
-    }
-
-    fn consumer(&self) -> crate::Result<<I as Interface>::Consumer> {
-        Ok(<I as Interface>::consumer(&self.instance_id))
-    }
-}
-
-pub struct DefaultInstanceBuilder<I: Interface> {
-    instance_id: InstanceSpecifier,
-    _phantom_data: PhantomData<I>,
-}
-
-impl<I: Interface> Builder for DefaultInstanceBuilder<I> {
-    type Output = DefaultInstance<I>;
-    fn build(self) -> crate::Result<Self::Output> {
-        Ok(DefaultInstance {
-            instance_id: self.instance_id,
-            _phantom_data: PhantomData,
-        })
-    }
-}
-impl<I: Interface> InstanceBuilder<I> for DefaultInstanceBuilder<I> {
-    fn key_str(mut self, key: &str, value: &str) -> Self {
-        todo!();
-        self
-    }
-}
-
-impl<I: Interface> DefaultInstanceBuilder<I> {
-    pub fn new(instance_id: InstanceSpecifier) -> Self {
-        Self {
-            instance_id,
-            _phantom_data: PhantomData,
-        }
-    }
-}
-*/
-
-struct SampleInstanceImpl<I: Interface> {
+pub struct SampleInstanceImpl<I: Interface> {
     _interface: PhantomData<I>,
+    instance_specifier: InstanceSpecifier,
 }
 
-impl<I: Interface> Instance<I> for SampleInstanceImpl<I>
+impl<I> Instance<I> for SampleInstanceImpl<I>
 where
-    I: SampleInstance<I>,
+    I: SampleInstance<I> + Interface,
 {
     type ProducerBuilder = <I as SampleInstance<I>>::ProducerBuilder;
     type ConsumerBuilder = <I as SampleInstance<I>>::ConsumerBuilder;
@@ -93,8 +41,11 @@ where
 
 pub struct RuntimeImpl {}
 impl crate::Runtime for RuntimeImpl {
-    type InstanceSpecifier = crate::InstanceSpecifier;
-    type Instance<I>
+    type InstanceSpecifier = InstanceSpecifier;
+
+    // TBD: Impl for the to-be-done link between (runtime-agnostic) interface and (runtime.aware) instance
+
+    /* type Instance<I>
         = SampleInstanceImpl<I>
     where
         I: Interface;
@@ -104,6 +55,18 @@ impl crate::Runtime for RuntimeImpl {
         instance_specifier: Self::InstanceSpecifier,
     ) -> Self::Instance<I> {
         <I as SampleInstance<I>>::new(instance_specifier)
+    } */
+}
+
+impl RuntimeImpl {
+    pub fn make_instance<I: Interface + SampleInstance<I>>(
+        &self,
+        instance_specifier: <Self as crate::Runtime>::InstanceSpecifier,
+    ) -> SampleInstanceImpl<I> {
+        SampleInstanceImpl {
+            _interface: PhantomData,
+            instance_specifier,
+        }
     }
 }
 

--- a/com-api/src/sample_interface.rs
+++ b/com-api/src/sample_interface.rs
@@ -1,0 +1,71 @@
+//! This is the "generated" code for an interface that looks like this (pseudo-IDL):
+//!
+//! ```poor-mans-idl
+//! interface Auto {
+//!     linkes_rad: Event<Rad>,
+//!     auspuff: Event<Auspuff>,
+//!     set_blinker_zustand: FnMut(blinkmodus: BlinkModus) -> Result<bool>,
+//! }
+//! ```
+
+use crate::*;
+
+pub(super) struct Rad {}
+unsafe impl Reloc for Rad {}
+
+pub(super) struct Auspuff {}
+unsafe impl Reloc for Auspuff {}
+
+pub(super) struct AutoInterface {}
+
+/// Generic
+impl Interface for AutoInterface {}
+
+// Specific code for the "sample" runtime
+// TODO: VIOLATES ORPHAN RULES, IMPOSSIBLE OUTSIDE CRATE!!11
+impl Instance<sample_impl::RuntimeImpl> for sample_impl::SampleInstanceImpl<AutoInterface> {
+    type ProducerBuilder = AutoProducerBuilder;
+    type ConsumerBuilder = AutoConsumerBuilder;
+
+    fn producer(&self) -> Self::ProducerBuilder {
+        AutoProducerBuilder {}
+    }
+
+    fn consumer(&self) -> Self::ConsumerBuilder {
+        AutoConsumerBuilder {}
+    }
+}
+
+pub(super) struct AutoProducerBuilder {}
+
+impl Builder for AutoProducerBuilder {
+    type Output = AutoProducer;
+
+    fn build(self) -> Result<Self::Output> {
+        todo!()
+    }
+}
+
+impl ProducerBuilder<sample_impl::RuntimeImpl> for AutoProducerBuilder {}
+
+pub(super) struct AutoConsumerBuilder {}
+
+impl Builder for AutoConsumerBuilder {
+    type Output = AutoConsumer;
+
+    fn build(self) -> Result<Self::Output> {
+        todo!()
+    }
+}
+
+impl ConsumerBuilder<sample_impl::RuntimeImpl> for AutoConsumerBuilder {}
+
+pub(super) struct AutoProducer {
+    pub linkes_rad: sample_impl::Publisher<Rad>,
+    pub auspuff: sample_impl::Publisher<Auspuff>,
+}
+
+pub(super) struct AutoConsumer {
+    pub linkes_rad: sample_impl::SubscriberImpl<Rad>,
+    pub auspuff: sample_impl::SubscriberImpl<Auspuff>,
+}


### PR DESCRIPTION
This PR is far from perfect but allows for some comments already. The main points to be fixed:
* There is no generic solution yet how to turn an interface into an instance.
* There is a violation of the orphan rules. This doesn't really show here as the sample code and the API are in the same crate. We need to separate those entities into
  * API crate
  * Sample runtime crate
  * Sample user code crate