### PR TITLE
Add test for async consumer use case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,46 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "com-api"
@@ -19,6 +55,7 @@ dependencies = [
  "com-api",
  "com-api-sample-gen",
  "com-api-sample-runtime",
+ "tokio",
 ]
 
 [[package]]
@@ -127,10 +164,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -163,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,7 +256,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/com-api-example/Cargo.toml
+++ b/com-api-example/Cargo.toml
@@ -11,3 +11,4 @@ license = "Apache-2.0"
 com-api = { path = "../com-api" }
 com-api-sample-gen = { path = "../com-api-sample-gen" }
 com-api-sample-runtime = { path = "../com-api-sample-runtime" }
+tokio = { version = "~1.43", features = ["rt-multi-thread", "macros", "test-util"] }

--- a/com-api-example/src/main.rs
+++ b/com-api-example/src/main.rs
@@ -59,34 +59,32 @@ mod test {
         let subscribed = consumer.left_tire.subscribe(3).unwrap();
 
         // Create sample buffer to be used during receive
-        let mut sample_buf = Some(SampleContainer::new());
+        let mut sample_buf = SampleContainer::new();
         for _ in 0..10 {
-            match subscribed.try_receive(sample_buf.take().unwrap(), 1) {
-                (_, Ok(0)) => panic!("No sample received"),
-                (mut buf, Ok(x)) => {
-                    let sample = buf.pop_front().unwrap();
-                    sample_buf = Some(buf); // Reuse the buffer
+            match subscribed.try_receive(&mut sample_buf, 1) {
+                Ok(0) => panic!("No sample received"),
+                Ok(x) => {
+                    let sample = sample_buf.pop_front().unwrap();
                     println!("{} samples received: sample[0] = {:?}", x, *sample)
                 }
-                (_, Err(e)) => panic!("{:?}", e),
+                Err(e) => panic!("{:?}", e),
             }
         }
     }
 
     async fn async_data_processor_fn(subscribed: impl Subscription<Tire>) {
-        let mut buffer = Some(SampleContainer::new());
+        let mut buffer = SampleContainer::new();
         for _ in 0..10 {
-            match subscribed.receive(buffer.take().unwrap(), 1, 1).await {
-                (_, Ok(0)) => panic!("No sample received"),
-                (buf, Ok(num_samples)) => {
+            match subscribed.receive(&mut buffer, 1, 1).await {
+                Ok(0) => panic!("No sample received"),
+                Ok(num_samples) => {
                     println!(
                         "{} samples received: sample[0] = {:?}",
                         num_samples,
-                        *buf.front().unwrap()
+                        *buffer.front().unwrap()
                     );
-                    buffer = Some(buf);
                 }
-                (_, Err(e)) => panic!("{:?}", e),
+                Err(e) => panic!("{:?}", e),
             }
         }
     }
@@ -108,25 +106,6 @@ mod test {
 
         // Subscribe to one event
         let subscribed = consumer.left_tire.subscribe(3).unwrap();
-
-        /*let async_data_processor_closure = async move {
-            let mut buffer = Some(SampleContainer::new());
-            for _ in 0..10 {
-                match subscribed.receive(buffer.take().unwrap(), 1, 1).await {
-                    (_, Ok(0)) => panic!("No sample received"),
-                    (buf, Ok(num_samples)) => {
-                        println!(
-                            "{} samples received: sample[0] = {:?}",
-                            num_samples,
-                            *buf.front().unwrap()
-                        );
-                        buffer = Some(buf);
-                    }
-                    (_, Err(e)) => panic!("{:?}", e),
-                }
-            }
-        };
-        tokio::spawn(async_data_processor_closure).await.unwrap();*/
 
         tokio::spawn(async_data_processor_fn(subscribed))
             .await

--- a/com-api-example/src/main.rs
+++ b/com-api-example/src/main.rs
@@ -16,10 +16,11 @@ fn main() {
 #[cfg(test)]
 mod test {
     use com_api::{
-        Builder, ConsumerDescriptor, InstanceSpecifier, Producer, SampleMaybeUninit, SampleMut,
-        ServiceDiscovery, Subscriber, Subscription,
+        Builder, ConsumerDescriptor, InstanceSpecifier, Producer, Runtime, Sample, SampleContainer,
+        SampleMaybeUninit, SampleMut, ServiceDiscovery, Subscriber, Subscription,
     };
     use com_api_sample_gen::{Tire, VehicleInterface};
+    use com_api_sample_runtime::RuntimeBuilderImpl;
     use std::collections::VecDeque;
 
     #[test]
@@ -58,7 +59,7 @@ mod test {
         let subscribed = consumer.left_tire.subscribe(3).unwrap();
 
         // Create sample buffer to be used during receive
-        let mut sample_buf = Some(VecDeque::new());
+        let mut sample_buf = Some(SampleContainer::new());
         for _ in 0..10 {
             match subscribed.try_receive(sample_buf.take().unwrap(), 1) {
                 (_, Ok(0)) => panic!("No sample received"),
@@ -70,5 +71,65 @@ mod test {
                 (_, Err(e)) => panic!("{:?}", e),
             }
         }
+    }
+
+    async fn async_data_processor_fn(subscribed: impl Subscription<Tire>) {
+        let mut buffer = Some(SampleContainer::new());
+        for _ in 0..10 {
+            match subscribed.receive(buffer.take().unwrap(), 1, 1).await {
+                (_, Ok(0)) => panic!("No sample received"),
+                (buf, Ok(num_samples)) => {
+                    println!(
+                        "{} samples received: sample[0] = {:?}",
+                        num_samples,
+                        *buf.front().unwrap()
+                    );
+                    buffer = Some(buf);
+                }
+                (_, Err(e)) => panic!("{:?}", e),
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn schedule_subscription_on_mt_scheduler() {
+        let runtime_builder = com_api_sample_runtime::RuntimeBuilderImpl::new();
+        let runtime = runtime_builder.build().unwrap();
+
+        let consumer_discovery = runtime.find_service::<VehicleInterface>(InstanceSpecifier {});
+        let available_service_instances = consumer_discovery.get_available_instances().unwrap();
+
+        // Create consumer from first discovered service
+        let consumer_builder = available_service_instances
+            .into_iter()
+            .find(|desc| desc.get_instance_id() == 42)
+            .unwrap();
+        let consumer = consumer_builder.build().unwrap();
+
+        // Subscribe to one event
+        let subscribed = consumer.left_tire.subscribe(3).unwrap();
+
+        /*let async_data_processor_closure = async move {
+            let mut buffer = Some(SampleContainer::new());
+            for _ in 0..10 {
+                match subscribed.receive(buffer.take().unwrap(), 1, 1).await {
+                    (_, Ok(0)) => panic!("No sample received"),
+                    (buf, Ok(num_samples)) => {
+                        println!(
+                            "{} samples received: sample[0] = {:?}",
+                            num_samples,
+                            *buf.front().unwrap()
+                        );
+                        buffer = Some(buf);
+                    }
+                    (_, Err(e)) => panic!("{:?}", e),
+                }
+            }
+        };
+        tokio::spawn(async_data_processor_closure).await.unwrap();*/
+
+        tokio::spawn(async_data_processor_fn(subscribed))
+            .await
+            .expect("Error returned from task");
     }
 }

--- a/com-api-example/src/main.rs
+++ b/com-api-example/src/main.rs
@@ -16,12 +16,10 @@ fn main() {
 #[cfg(test)]
 mod test {
     use com_api::{
-        Builder, ConsumerDescriptor, InstanceSpecifier, Producer, Runtime, Sample, SampleContainer,
+        Builder, ConsumerDescriptor, InstanceSpecifier, Producer, SampleContainer,
         SampleMaybeUninit, SampleMut, ServiceDiscovery, Subscriber, Subscription,
     };
     use com_api_sample_gen::{Tire, VehicleInterface};
-    use com_api_sample_runtime::RuntimeBuilderImpl;
-    use std::collections::VecDeque;
 
     #[test]
     fn create_producer() {

--- a/com-api-sample-runtime/src/lib.rs
+++ b/com-api-sample-runtime/src/lib.rs
@@ -35,7 +35,7 @@ impl RuntimeImpl {
     // If yes, this trait is certainly located here since
     pub fn find_service<I: Interface>(
         &self,
-        instance_specifier: InstanceSpecifier,
+        _instance_specifier: InstanceSpecifier,
     ) -> SampleConsumerDiscovery<I> {
         SampleConsumerDiscovery {
             _interface: PhantomData,
@@ -46,7 +46,7 @@ impl RuntimeImpl {
         &self,
         instance_specifier: InstanceSpecifier,
     ) -> SampleProducerBuilder<I> {
-        SampleProducerBuilder::new(&self, instance_specifier)
+        SampleProducerBuilder::new(self, instance_specifier)
     }
 }
 
@@ -125,8 +125,8 @@ impl<'a, T> PartialOrd for Sample<'a, T>
 where
     T: Send + Reloc,
 {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.id.partial_cmp(&other.id)
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -224,7 +224,7 @@ impl<T> Default for SubscribableImpl<T> {
 impl<T: Reloc + Send> Subscriber<T> for SubscribableImpl<T> {
     type Subscription = SubscriberImpl<T>;
 
-    fn subscribe(self, max_num_samples: usize) -> com_api::Result<Self::Subscription> {
+    fn subscribe(self, _max_num_samples: usize) -> com_api::Result<Self::Subscription> {
         Ok(SubscriberImpl::new())
     }
 }
@@ -268,17 +268,18 @@ where
 
     fn try_receive<'a>(
         &'a self,
-        scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
-        max_samples: usize,
+        _scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
+        _max_samples: usize,
     ) -> com_api::Result<usize> {
         todo!()
     }
 
+    #[allow(clippy::manual_async_fn)]
     fn receive<'a>(
         &'a self,
-        scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
-        new_samples: usize,
-        max_samples: usize,
+        _scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
+        _new_samples: usize,
+        _max_samples: usize,
     ) -> impl Future<Output = com_api::Result<usize>> + Send {
         async { todo!() }
     }
@@ -286,6 +287,15 @@ where
 
 pub struct Publisher<T> {
     _data: PhantomData<T>,
+}
+
+impl<T> Default for Publisher<T>
+where
+    T: Reloc + Send,
+{
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T> Publisher<T>
@@ -296,7 +306,7 @@ where
         Self { _data: PhantomData }
     }
 
-    pub fn allocate(&self) -> com_api::Result<SampleMaybeUninit<T>> {
+    pub fn allocate<'a>(&'a self) -> com_api::Result<SampleMaybeUninit<'a, T>> {
         Ok(SampleMaybeUninit {
             data: MaybeUninit::uninit(),
             _lifetime: PhantomData,
@@ -309,7 +319,7 @@ pub struct SampleConsumerDiscovery<I> {
 }
 
 impl<I> SampleConsumerDiscovery<I> {
-    fn new(_runtime: &RuntimeImpl, instance_specifier: InstanceSpecifier) -> Self {
+    fn new(_runtime: &RuntimeImpl, _instance_specifier: InstanceSpecifier) -> Self {
         Self {
             _interface: PhantomData,
         }
@@ -377,6 +387,12 @@ impl Builder<RuntimeImpl> for RuntimeBuilderImpl {
 impl com_api::RuntimeBuilder<RuntimeImpl> for RuntimeBuilderImpl {
     fn load_config(&mut self, _config: &Path) -> &mut Self {
         self
+    }
+}
+
+impl Default for RuntimeBuilderImpl {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/com-api-sample-runtime/src/lib.rs
+++ b/com-api-sample-runtime/src/lib.rs
@@ -266,26 +266,20 @@ where
         Default::default()
     }
 
-    fn try_receive<'a, C>(&self, scratch: C, max_samples: usize) -> (C, com_api::Result<usize>)
-    where
-        Self: 'a,
-        T: 'a,
-        C: SampleContainer<Self::Sample<'a>> + 'a,
-    {
+    fn try_receive<'a>(
+        &'a self,
+        scratch: SampleContainer<Self::Sample<'a>>,
+        max_samples: usize,
+    ) -> (SampleContainer<Self::Sample<'a>>, com_api::Result<usize>) {
         todo!()
     }
 
-    fn receive<'a, C>(
-        &self,
-        scratch: C,
+    fn receive<'a>(
+        &'a self,
+        scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = (C, com_api::Result<usize>)> + Send
-    where
-        Self: 'a,
-        T: 'a,
-        C: SampleContainer<Self::Sample<'a>> + 'a,
-    {
+    ) -> impl Future<Output = (SampleContainer<Sample<T>>, com_api::Result<usize>)> + Send {
         async { todo!() }
     }
 }
@@ -395,18 +389,21 @@ impl RuntimeBuilderImpl {
 
 #[cfg(test)]
 mod test {
-    use com_api::Subscription;
-    use std::collections::VecDeque;
+    use com_api::{SampleContainer, Subscription};
 
     #[test]
     fn receive_stuff() {
         let test_subscriber = super::SubscriberImpl::<u32>::new();
         for _ in 0..10 {
-            let sample_buf = VecDeque::new();
+            let sample_buf = SampleContainer::new();
             match test_subscriber.try_receive(sample_buf, 1) {
                 (_, Ok(0)) => panic!("No sample received"),
                 (sample_buf, Ok(x)) => {
-                    println!("{} samples received: sample[0] = {}", x, *sample_buf[0])
+                    println!(
+                        "{} samples received: sample[0] = {}",
+                        x,
+                        *sample_buf.front().unwrap()
+                    )
                 }
                 (_, Err(e)) => panic!("{:?}", e),
             }
@@ -418,11 +415,15 @@ mod test {
         let test_subscriber = super::SubscriberImpl::<u32>::new();
         // block on an asynchronous reception of data from test_subscriber
         futures::executor::block_on(async {
-            let sample_buf = VecDeque::new();
+            let sample_buf = SampleContainer::new();
             match test_subscriber.receive(sample_buf, 1, 1).await {
                 (_, Ok(0)) => panic!("No sample received"),
                 (sample_buf, Ok(x)) => {
-                    println!("{} samples received: sample[0] = {}", x, *sample_buf[0])
+                    println!(
+                        "{} samples received: sample[0] = {}",
+                        x,
+                        *sample_buf.front().unwrap()
+                    )
                 }
                 (_, Err(e)) => panic!("{:?}", e),
             }

--- a/com-api-sample-runtime/src/lib.rs
+++ b/com-api-sample-runtime/src/lib.rs
@@ -268,18 +268,18 @@ where
 
     fn try_receive<'a>(
         &'a self,
-        scratch: SampleContainer<Self::Sample<'a>>,
+        scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
         max_samples: usize,
-    ) -> (SampleContainer<Self::Sample<'a>>, com_api::Result<usize>) {
+    ) -> com_api::Result<usize> {
         todo!()
     }
 
     fn receive<'a>(
         &'a self,
-        scratch: SampleContainer<Self::Sample<'a>>,
+        scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = (SampleContainer<Sample<T>>, com_api::Result<usize>)> + Send {
+    ) -> impl Future<Output = com_api::Result<usize>> + Send {
         async { todo!() }
     }
 }
@@ -395,17 +395,18 @@ mod test {
     fn receive_stuff() {
         let test_subscriber = super::SubscriberImpl::<u32>::new();
         for _ in 0..10 {
-            let sample_buf = SampleContainer::new();
-            match test_subscriber.try_receive(sample_buf, 1) {
-                (_, Ok(0)) => panic!("No sample received"),
-                (sample_buf, Ok(x)) => {
+            let mut sample_buf = SampleContainer::new();
+            let receive_result = test_subscriber.try_receive(&mut sample_buf, 1);
+            match receive_result {
+                Ok(0) => panic!("No sample received"),
+                Ok(x) => {
                     println!(
                         "{} samples received: sample[0] = {}",
                         x,
                         *sample_buf.front().unwrap()
                     )
                 }
-                (_, Err(e)) => panic!("{:?}", e),
+                Err(e) => panic!("{:?}", e),
             }
         }
     }
@@ -415,17 +416,17 @@ mod test {
         let test_subscriber = super::SubscriberImpl::<u32>::new();
         // block on an asynchronous reception of data from test_subscriber
         futures::executor::block_on(async {
-            let sample_buf = SampleContainer::new();
-            match test_subscriber.receive(sample_buf, 1, 1).await {
-                (_, Ok(0)) => panic!("No sample received"),
-                (sample_buf, Ok(x)) => {
+            let mut sample_buf = SampleContainer::new();
+            match test_subscriber.receive(&mut sample_buf, 1, 1).await {
+                Ok(0) => panic!("No sample received"),
+                Ok(x) => {
                     println!(
                         "{} samples received: sample[0] = {}",
                         x,
                         *sample_buf.front().unwrap()
                     )
                 }
-                (_, Err(e)) => panic!("{:?}", e),
+                Err(e) => panic!("{:?}", e),
             }
         })
     }

--- a/com-api/src/lib.rs
+++ b/com-api/src/lib.rs
@@ -283,9 +283,9 @@ pub trait Subscription<T: Reloc + Send> {
     /// TODO: samples.
     fn try_receive<'a>(
         &'a self,
-        scratch: SampleContainer<Self::Sample<'a>>,
+        scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
         max_samples: usize,
-    ) -> (SampleContainer<Self::Sample<'a>>, Result<usize>);
+    ) -> Result<usize>;
 
     /// This method returns a future that resolves as soon as at least `new_samples` samples have
     /// been transferred from the communication buffer to the sample container.
@@ -296,8 +296,8 @@ pub trait Subscription<T: Reloc + Send> {
     /// TODO: See above for C++ limitations.
     fn receive<'a>(
         &'a self,
-        scratch: SampleContainer<Self::Sample<'a>>,
+        scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + Send;
+    ) -> impl Future<Output = Result<usize>> + Send;
 }

--- a/com-api/src/lib.rs
+++ b/com-api/src/lib.rs
@@ -242,7 +242,7 @@ impl<S> SampleContainer<S> {
     where
         S: Sample<T>,
     {
-        self.inner.get(0).map(<S as Deref>::deref)
+        self.inner.front().map(<S as Deref>::deref)
     }
 }
 

--- a/com-api/src/lib.rs
+++ b/com-api/src/lib.rs
@@ -200,43 +200,57 @@ pub trait Subscriber<T: Reloc + Send> {
     fn subscribe(self, max_num_samples: usize) -> Result<Self::Subscription>;
 }
 
-pub trait SampleContainer<S>: IntoIterator<Item = S> {
-    fn iter<'a, T>(&'a self) -> impl Iterator<Item = &'a T>
-    where
-        S: Sample<T>,
-        T: Reloc + Send + 'a;
-
-    /// Will remove the first element from the container (if any) and return it to the user.
-    fn pop_front(&mut self) -> Option<S>;
-
-    /// Will add a sample to the end of the container.
-    fn push_back(&mut self, new: S) -> Result<()>;
+pub struct SampleContainer<S> {
+    inner: VecDeque<S>,
 }
 
-impl<S> SampleContainer<S> for VecDeque<S> {
-    fn iter<'a, T>(&'a self) -> impl Iterator<Item = &'a T>
+impl<S> Default for SampleContainer<S> {
+    fn default() -> Self {
+        Self {
+            inner: VecDeque::new(),
+        }
+    }
+}
+
+impl<S> SampleContainer<S> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn iter<'a, T>(&'a self) -> impl Iterator<Item = &'a T>
     where
         S: Sample<T>,
         T: Reloc + Send + 'a,
     {
-        self.iter().map(<S as Deref>::deref)
+        self.inner.iter().map(<S as Deref>::deref)
     }
 
-    fn pop_front(&mut self) -> Option<S> {
-        self.pop_front()
+    pub fn pop_front(&mut self) -> Option<S> {
+        self.inner.pop_front()
     }
 
-    fn push_back(&mut self, new: S) -> Result<()> {
-        self.push_back(new);
+    pub fn push_back(&mut self, new: S) -> Result<()> {
+        self.inner.push_back(new);
         Ok(())
+    }
+
+    pub fn sample_count(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn front<T: Reloc + Send>(&self) -> Option<&T>
+    where
+        S: Sample<T>,
+    {
+        self.inner.get(0).map(<S as Deref>::deref)
     }
 }
 
 pub trait Subscription<T: Reloc + Send> {
     type Subscriber: Subscriber<T>;
-    type Sample<'a>
+    type Sample<'a>: Sample<T>
     where
-        T: 'a;
+        Self: 'a;
 
     fn unsubscribe(self) -> Self::Subscriber;
 
@@ -267,11 +281,11 @@ pub trait Subscription<T: Reloc + Send> {
     ///
     /// TODO: C++ cannot fully support this yet since there is no way to retain potentially-reusable
     /// TODO: samples.
-    fn try_receive<'a, C>(&self, scratch: C, max_samples: usize) -> (C, Result<usize>)
-    where
-        Self: 'a,
-        T: 'a,
-        C: SampleContainer<Self::Sample<'a>> + 'a;
+    fn try_receive<'a>(
+        &'a self,
+        scratch: SampleContainer<Self::Sample<'a>>,
+        max_samples: usize,
+    ) -> (SampleContainer<Self::Sample<'a>>, Result<usize>);
 
     /// This method returns a future that resolves as soon as at least `new_samples` samples have
     /// been transferred from the communication buffer to the sample container.
@@ -280,14 +294,10 @@ pub trait Subscription<T: Reloc + Send> {
     /// to `try_receive`.
     ///
     /// TODO: See above for C++ limitations.
-    fn receive<'a, C>(
-        &self,
-        scratch: C,
+    fn receive<'a>(
+        &'a self,
+        scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = (C, Result<usize>)> + Send
-    where
-        Self: 'a,
-        T: 'a,
-        C: SampleContainer<Self::Sample<'a>> + 'a;
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + Send;
 }


### PR DESCRIPTION
The test tries to mimic a common pattern, which is the processing of incoming subscription data via an async function. The resulting Future shall be compatible with the spawn function of common executors (tokio in this case). This means that the Future itself and its output are Send + 'static.

In addition, also make the signature of [try_]receive object safe by removing the generic parameter and using a reference instead of consuming-then-returning the buffer.