### PR TITLE
Extend API for service discovery

### DIFF
--- a/com-api-example/src/main.rs
+++ b/com-api-example/src/main.rs
@@ -26,7 +26,8 @@ mod test {
         // Factory
         let runtime_builder = com_api_sample_runtime::RuntimeBuilderImpl::new();
         let runtime = runtime_builder.build().unwrap();
-        let producer_builder = runtime.producer_builder::<VehicleInterface>(InstanceSpecifier {});
+        let producer_builder =
+            runtime.producer_builder::<VehicleInterface>(InstanceSpecifier::MATCH_ANY);
         let producer = producer_builder.build().unwrap();
         let offered_producer = producer.offer().unwrap();
 
@@ -43,7 +44,9 @@ mod test {
         let runtime = runtime_builder.build().unwrap();
 
         // Create service discovery
-        let consumer_discovery = runtime.find_service::<VehicleInterface>(InstanceSpecifier {});
+        let consumer_discovery = runtime.find_service::<VehicleInterface>(
+            InstanceSpecifier::new("VehicleInterface:local/vehicle_provider").unwrap(),
+        );
         let available_service_instances = consumer_discovery.get_available_instances().unwrap();
 
         // Create consumer from first discovered service
@@ -92,7 +95,8 @@ mod test {
         let runtime_builder = com_api_sample_runtime::RuntimeBuilderImpl::new();
         let runtime = runtime_builder.build().unwrap();
 
-        let consumer_discovery = runtime.find_service::<VehicleInterface>(InstanceSpecifier {});
+        let consumer_discovery =
+            runtime.find_service::<VehicleInterface>(InstanceSpecifier::MATCH_ANY);
         let available_service_instances = consumer_discovery.get_available_instances().unwrap();
 
         // Create consumer from first discovered service

--- a/com-api/src/lib.rs
+++ b/com-api/src/lib.rs
@@ -73,7 +73,53 @@ where
     fn load_config(&mut self, config: &Path) -> &mut Self;
 }
 
-pub struct InstanceSpecifier {}
+/// Technology independent description of a service instance "location"
+///
+/// The string shall describe where to find a certain instance of a service. Each level shall look
+/// like this
+/// <InterfaceName>:my/path/to/service_name
+pub struct InstanceSpecifier {
+    inner: Option<String>,
+}
+
+impl InstanceSpecifier {
+    /// Instance specifier that will match any instance. This can be used to find all
+    /// instances of a certain interface during service discovery.
+    pub const MATCH_ANY: Self = InstanceSpecifier { inner: None };
+
+    fn check_str(_service_name: &str) -> bool {
+        todo!()
+    }
+
+    /// Create a new instance specifier, using the string-like input as the path to the
+    /// instance.
+    ///
+    /// The returned instance specifier will only match if the instance exactly matches the given
+    /// string.
+    pub fn new(service_name: impl AsRef<str>) -> Result<InstanceSpecifier> {
+        let service_name = service_name.as_ref();
+        if Self::check_str(service_name) {
+            Ok(Self {
+                inner: Some(service_name.to_string()),
+            })
+        } else {
+            Err(Error::Fail)
+        }
+    }
+}
+
+impl TryFrom<&str> for InstanceSpecifier {
+    type Error = Error;
+    fn try_from(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+impl AsRef<str> for InstanceSpecifier {
+    fn as_ref(&self) -> &str {
+        self.inner.as_ref().map(String::as_str).unwrap_or("[ANY]")
+    }
+}
 
 /// This trait shall ensure that we can safely use an instance of the implementing type across
 /// address boundaries. This property may be violated by the following circumstances:


### PR DESCRIPTION
* Add methods to create instances of InstanceSpecifier for both one specific instance as well as an InstanceSpecifier that matches any instance.