### PR TITLE
Renaming in com_api

### DIFF
--- a/com-api/Cargo.lock
+++ b/com-api/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -29,14 +29,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "com-api"
@@ -191,21 +191,21 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -269,9 +269,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.2"
+version = "1.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941bf965858b48d716811314431e8cf749811648475f4a6dd67ff5ceef0f8ed9"
+checksum = "9a71332c8f602f51b88850a6e66aff65cd3d6f0e0103c20b76c6c4634bc7a5ab"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -302,70 +302,12 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"

--- a/com-api/com-api-concept/src/lib.rs
+++ b/com-api/com-api-concept/src/lib.rs
@@ -12,7 +12,7 @@
 //! This crate defines the concepts and traits of the COM API. It does not provide any concrete
 //! implementations. It is meant to be used as a common interface for different implementations
 //! of the COM API, e.g., for different IPC backends.
-//! 
+//!
 //! # API Design principles
 //!
 //! - We stick to the builder pattern down to a single service (TODO: Should this be introduced to the C++ API?)
@@ -61,20 +61,20 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Generic trait for all "factory-like" types
-pub trait Builder<Output> {
+pub trait BuilderConcept<Output> {
     /// TODO: Should this be &mut self so that this can be turned into a trait object?
     fn build(self) -> Result<Output>;
 }
 
 /// This represents the com implementation and acts as a root for all types and objects provided by
 /// the implementation.
-pub trait Runtime {
-    type Sample<'a, T: Reloc + Send + std::fmt::Debug + 'a>: Sample<T>;
+pub trait AdapterConcept {
+    type Sample<'a, T: Reloc + Send + std::fmt::Debug + 'a>: SampleConcept<T>;
 }
 
-pub trait RuntimeBuilder<B>: Builder<B>
+pub trait AdapterBuilderConcept<B>: BuilderConcept<B>
 where
-    B: Runtime,
+    B: AdapterConcept,
 {
     fn load_config(&mut self, config: &Path) -> &mut Self;
 }
@@ -109,7 +109,7 @@ unsafe impl Reloc for u32 {}
 ///
 /// The ordering of SamplePtrs is total over the reception order
 // TODO: C++ doesn't yet support this. Expose API to compare SamplePtr ages.
-pub trait Sample<T>: Deref<Target = T> + Send + PartialOrd + Ord
+pub trait SampleConcept<T>: Deref<Target = T> + Send + PartialOrd + Ord
 where
     T: Send + Reloc,
 {
@@ -119,12 +119,12 @@ where
 ///
 /// By implementing the `DerefMut` trait implementations of the trait support the `.` operator for dereferencing.
 /// The buffers with its data lives as long as there are references to it existing in the framework.
-pub trait SampleMut<T>: DerefMut<Target = T>
+pub trait SampleMutConcept<T>: DerefMut<Target = T>
 where
     T: Send + Reloc,
 {
     /// The associated read-only sample type.
-    type Sample: Sample<T>;
+    type Sample: SampleConcept<T>;
 
     /// Consume the sample into an immutable sample.
     fn into_sample(self) -> Self::Sample;
@@ -140,12 +140,12 @@ where
 ///
 /// TODO: Shall we also require DerefMut<Target=MaybeUninit<T>> from implementing types? How to deal
 /// TODO: with the ambiguous assume_init() then?
-pub trait SampleMaybeUninit<T>
+pub trait SampleMaybeUninitConcept<T>
 where
     T: Send + Reloc,
 {
     /// Buffer type for mutable data after initialization
-    type SampleMut: SampleMut<T>;
+    type SampleMut: SampleMutConcept<T>;
     /// Render the buffer initialized for mutable access.
     ///
     /// This corresponds to `MaybeUninit::assume_init`.
@@ -162,45 +162,51 @@ where
     fn write(self, value: T) -> Self::SampleMut;
 }
 
-pub trait Interface {}
+pub trait InterfaceConcept {}
 
-pub trait OfferedProducer {
-    type Interface: Interface;
-    type Producer: Producer<Interface = Self::Interface>;
+pub trait OfferedProducerConcept {
+    type Interface: InterfaceConcept;
+    type Producer: ProducerConcept<Interface = Self::Interface>;
 
     fn unoffer(self) -> Self::Producer;
 }
 
-pub trait Producer {
-    type Interface: Interface;
-    type OfferedProducer: OfferedProducer<Interface = Self::Interface>;
+pub trait ProducerConcept {
+    type Interface: InterfaceConcept;
+    type OfferedProducer: OfferedProducerConcept<Interface = Self::Interface>;
 
     fn offer(self) -> Result<Self::OfferedProducer>;
 }
 
-pub trait Consumer {}
+pub trait ConsumerConcept {}
 
-pub trait ProducerBuilder<I: Interface, R: Runtime, P: Producer<Interface = I>>:
-    Builder<P>
+pub trait ProducerBuilderConcept<
+    I: InterfaceConcept,
+    R: AdapterConcept,
+    P: ProducerConcept<Interface = I>,
+>: BuilderConcept<P>
 {
 }
 
-pub trait ServiceDiscovery<I: Interface, R: Runtime> {
-    type ConsumerBuilder: ConsumerBuilder<I, R>;
+pub trait ServiceDiscoveryConcept<I: InterfaceConcept, R: AdapterConcept> {
+    type ConsumerBuilder: ConsumerBuilderConcept<I, R>;
     type ServiceEnumerator: IntoIterator<Item = Self::ConsumerBuilder>;
 
     fn get_available_instances(&self) -> Result<Self::ServiceEnumerator>;
     // TODO: Provide an async stream for newly available services / ServiceDescriptors
 }
 
-pub trait ConsumerDescriptor<R: Runtime> {
+pub trait ConsumerDescriptorConcept<R: AdapterConcept> {
     fn get_instance_id(&self) -> usize; // TODO: Turn return type into separate type
 }
 
-pub trait ConsumerBuilder<I: Interface, R: Runtime>: ConsumerDescriptor<R> {}
+pub trait ConsumerBuilderConcept<I: InterfaceConcept, R: AdapterConcept>:
+    ConsumerDescriptorConcept<R>
+{
+}
 
-pub trait Subscriber<T: Reloc + Send> {
-    type Subscription: Subscription<T>;
+pub trait SubscriberConcept<T: Reloc + Send> {
+    type Subscription: SubscriptionConcept<T>;
 
     fn subscribe(self, max_num_samples: usize) -> Result<Self::Subscription>;
 }
@@ -224,7 +230,7 @@ impl<S> SampleContainer<S> {
 
     pub fn iter<'a, T>(&'a self) -> impl Iterator<Item = &'a T>
     where
-        S: Sample<T>,
+        S: SampleConcept<T>,
         T: Reloc + Send + 'a,
     {
         self.inner.iter().map(<S as Deref>::deref)
@@ -245,15 +251,15 @@ impl<S> SampleContainer<S> {
 
     pub fn front<T: Reloc + Send>(&self) -> Option<&T>
     where
-        S: Sample<T>,
+        S: SampleConcept<T>,
     {
         self.inner.front().map(<S as Deref>::deref)
     }
 }
 
-pub trait Subscription<T: Reloc + Send> {
-    type Subscriber: Subscriber<T>;
-    type Sample<'a>: Sample<T>
+pub trait SubscriptionConcept<T: Reloc + Send> {
+    type Subscriber: SubscriberConcept<T>;
+    type Sample<'a>: SampleConcept<T>
     where
         Self: 'a;
 

--- a/com-api/com-api-runtime-lola/src/lib.rs
+++ b/com-api/com-api-runtime-lola/src/lib.rs
@@ -23,33 +23,35 @@ use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 
 use com_api_concept::{
-    Builder, ConsumerBuilder, ConsumerDescriptor, InstanceSpecifier, Interface, Reloc, Runtime,
-    SampleContainer, ServiceDiscovery, Subscriber, Subscription,
+    AdapterConcept, BuilderConcept, ConsumerBuilderConcept, ConsumerDescriptorConcept,
+    InstanceSpecifier, InterfaceConcept, Reloc, SampleConcept, SampleContainer,
+    SampleMaybeUninitConcept, SampleMutConcept, ServiceDiscoveryConcept, SubscriberConcept,
+    SubscriptionConcept,
 };
 
-pub struct LolaRuntimeImpl {}
+pub struct LolaAdapter {}
 
-impl Runtime for LolaRuntimeImpl {
-    type Sample<'a, T: Reloc + Send + 'a + std::fmt::Debug> = Sample<'a, T>;
+impl AdapterConcept for LolaAdapter {
+    type Sample<'a, T: Reloc + Send + 'a + std::fmt::Debug> = LolaSample<'a, T>;
 }
 
-impl LolaRuntimeImpl {
+impl LolaAdapter {
     // TODO: Any chance that these can be moved to a trait so that this becomes more testable?
     // If yes, this trait is certainly located here since
-    pub fn find_service<I: Interface>(
+    pub fn find_service<I: InterfaceConcept>(
         &self,
         _instance_specifier: InstanceSpecifier,
-    ) -> SampleConsumerDiscovery<I> {
-        SampleConsumerDiscovery {
+    ) -> LolaConsumerDiscovery<I> {
+        LolaConsumerDiscovery {
             _interface: PhantomData,
         }
     }
 
-    pub fn producer_builder<I: Interface>(
+    pub fn producer_builder<I: InterfaceConcept>(
         &self,
         instance_specifier: InstanceSpecifier,
-    ) -> SampleProducerBuilder<I> {
-        SampleProducerBuilder::new(self, instance_specifier)
+    ) -> LolaProducerBuilder<I> {
+        LolaProducerBuilder::new(self, instance_specifier)
     }
 }
 
@@ -75,7 +77,7 @@ where
     Test(Box<T>),
 }
 
-pub struct Sample<'a, T>
+pub struct LolaSample<'a, T>
 where
     T: Reloc + Send,
 {
@@ -85,7 +87,7 @@ where
 
 static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-impl<'a, T> From<T> for Sample<'a, T>
+impl<'a, T> From<T> for LolaSample<'a, T>
 where
     T: Reloc + Send,
 {
@@ -97,7 +99,7 @@ where
     }
 }
 
-impl<'a, T> Deref for Sample<'a, T>
+impl<'a, T> Deref for LolaSample<'a, T>
 where
     T: Reloc + Send,
 {
@@ -111,9 +113,9 @@ where
     }
 }
 
-impl<'a, T> com_api_concept::Sample<T> for Sample<'a, T> where T: Send + Reloc {}
+impl<'a, T> SampleConcept<T> for LolaSample<'a, T> where T: Send + Reloc {}
 
-impl<'a, T> PartialEq for Sample<'a, T>
+impl<'a, T> PartialEq for LolaSample<'a, T>
 where
     T: Send + Reloc,
 {
@@ -122,9 +124,9 @@ where
     }
 }
 
-impl<'a, T> Eq for Sample<'a, T> where T: Send + Reloc {}
+impl<'a, T> Eq for LolaSample<'a, T> where T: Send + Reloc {}
 
-impl<'a, T> PartialOrd for Sample<'a, T>
+impl<'a, T> PartialOrd for LolaSample<'a, T>
 where
     T: Send + Reloc,
 {
@@ -133,7 +135,7 @@ where
     }
 }
 
-impl<'a, T> Ord for Sample<'a, T>
+impl<'a, T> Ord for LolaSample<'a, T>
 where
     T: Send + Reloc,
 {
@@ -142,7 +144,7 @@ where
     }
 }
 
-pub struct SampleMut<'a, T>
+pub struct LolaSampleMut<'a, T>
 where
     T: Reloc,
 {
@@ -150,11 +152,11 @@ where
     _lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> com_api_concept::SampleMut<T> for SampleMut<'a, T>
+impl<'a, T> SampleMutConcept<T> for LolaSampleMut<'a, T>
 where
     T: Reloc + Send,
 {
-    type Sample = Sample<'a, T>;
+    type Sample = LolaSample<'a, T>;
 
     fn into_sample(self) -> Self::Sample {
         todo!()
@@ -165,7 +167,7 @@ where
     }
 }
 
-impl<'a, T> Deref for SampleMut<'a, T>
+impl<'a, T> Deref for LolaSampleMut<'a, T>
 where
     T: Reloc,
 {
@@ -176,7 +178,7 @@ where
     }
 }
 
-impl<'a, T> DerefMut for SampleMut<'a, T>
+impl<'a, T> DerefMut for LolaSampleMut<'a, T>
 where
     T: Reloc,
 {
@@ -185,7 +187,7 @@ where
     }
 }
 
-pub struct SampleMaybeUninit<'a, T>
+pub struct LolaSampleMaybeUninit<'a, T>
 where
     T: Reloc + Send,
 {
@@ -193,54 +195,54 @@ where
     _lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> com_api_concept::SampleMaybeUninit<T> for SampleMaybeUninit<'a, T>
+impl<'a, T> SampleMaybeUninitConcept<T> for LolaSampleMaybeUninit<'a, T>
 where
     T: Reloc + Send,
 {
-    type SampleMut = SampleMut<'a, T>;
+    type SampleMut = LolaSampleMut<'a, T>;
 
-    fn write(self, val: T) -> SampleMut<'a, T> {
-        SampleMut {
+    fn write(self, val: T) -> Self::SampleMut {
+        Self::SampleMut {
             data: val,
             _lifetime: PhantomData,
         }
     }
 
-    unsafe fn assume_init(self) -> SampleMut<'a, T> { 
-        SampleMut {
+    unsafe fn assume_init(self) -> Self::SampleMut {
+        Self::SampleMut {
             data: unsafe { self.data.assume_init() },
             _lifetime: PhantomData,
         }
     }
 }
 
-pub struct SubscribableImpl<T> {
+pub struct LolaSubscribable<T> {
     _data: PhantomData<T>,
 }
 
-impl<T> Default for SubscribableImpl<T> {
+impl<T> Default for LolaSubscribable<T> {
     fn default() -> Self {
         Self { _data: PhantomData }
     }
 }
 
-impl<T: Reloc + Send> Subscriber<T> for SubscribableImpl<T> {
-    type Subscription = SubscriberImpl<T>;
+impl<T: Reloc + Send> SubscriberConcept<T> for LolaSubscribable<T> {
+    type Subscription = LolaSubscriber<T>;
 
     fn subscribe(self, _max_num_samples: usize) -> com_api_concept::Result<Self::Subscription> {
-        Ok(SubscriberImpl::new())
+        Ok(LolaSubscriber::new())
     }
 }
 
 #[derive(Default)]
-pub struct SubscriberImpl<T>
+pub struct LolaSubscriber<T>
 where
     T: Reloc + Send,
 {
     data: VecDeque<T>,
 }
 
-impl<T> SubscriberImpl<T>
+impl<T> LolaSubscriber<T>
 where
     T: Reloc + Send,
 {
@@ -255,13 +257,13 @@ where
     }
 }
 
-impl<T> Subscription<T> for SubscriberImpl<T>
+impl<T> SubscriptionConcept<T> for LolaSubscriber<T>
 where
     T: Reloc + Send,
 {
-    type Subscriber = SubscribableImpl<T>;
+    type Subscriber = LolaSubscribable<T>;
     type Sample<'a>
-        = Sample<'a, T>
+        = LolaSample<'a, T>
     where
         T: 'a;
 
@@ -288,11 +290,11 @@ where
     }
 }
 
-pub struct Publisher<T> {
+pub struct LolaPublisher<T> {
     _data: PhantomData<T>,
 }
 
-impl<T> Default for Publisher<T>
+impl<T> Default for LolaPublisher<T>
 where
     T: Reloc + Send,
 {
@@ -301,7 +303,7 @@ where
     }
 }
 
-impl<T> Publisher<T>
+impl<T> LolaPublisher<T>
 where
     T: Reloc + Send,
 {
@@ -309,45 +311,45 @@ where
         Self { _data: PhantomData }
     }
 
-    pub fn allocate<'a>(&'a self) -> com_api_concept::Result<SampleMaybeUninit<'a, T>> {
-        Ok(SampleMaybeUninit {
+    pub fn allocate<'a>(&'a self) -> com_api_concept::Result<LolaSampleMaybeUninit<'a, T>> {
+        Ok(LolaSampleMaybeUninit {
             data: MaybeUninit::uninit(),
             _lifetime: PhantomData,
         })
     }
 }
 
-pub struct SampleConsumerDiscovery<I> {
+pub struct LolaConsumerDiscovery<I> {
     _interface: PhantomData<I>,
 }
 
-impl<I> SampleConsumerDiscovery<I> {
-    fn new(_runtime: &LolaRuntimeImpl, _instance_specifier: InstanceSpecifier) -> Self {
+impl<I> LolaConsumerDiscovery<I> {
+    fn new(_runtime: &LolaAdapter, _instance_specifier: InstanceSpecifier) -> Self {
         Self {
             _interface: PhantomData,
         }
     }
 }
 
-impl<I: Interface> ServiceDiscovery<I, LolaRuntimeImpl> for SampleConsumerDiscovery<I>
+impl<I: InterfaceConcept> ServiceDiscoveryConcept<I, LolaAdapter> for LolaConsumerDiscovery<I>
 where
-    SampleConsumerBuilder<I>: ConsumerBuilder<I, LolaRuntimeImpl>,
+    LolaConsumerBuilder<I>: ConsumerBuilderConcept<I, LolaAdapter>,
 {
-    type ConsumerBuilder = SampleConsumerBuilder<I>;
-    type ServiceEnumerator = Vec<SampleConsumerBuilder<I>>;
+    type ConsumerBuilder = LolaConsumerBuilder<I>;
+    type ServiceEnumerator = Vec<LolaConsumerBuilder<I>>;
 
     fn get_available_instances(&self) -> com_api_concept::Result<Self::ServiceEnumerator> {
         Ok(Vec::new())
     }
 }
 
-pub struct SampleProducerBuilder<I: Interface> {
+pub struct LolaProducerBuilder<I: InterfaceConcept> {
     instance_specifier: InstanceSpecifier,
     _interface: PhantomData<I>,
 }
 
-impl<I: Interface> SampleProducerBuilder<I> {
-    fn new(_runtime: &LolaRuntimeImpl, instance_specifier: InstanceSpecifier) -> Self {
+impl<I: InterfaceConcept> LolaProducerBuilder<I> {
+    fn new(_runtime: &LolaAdapter, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
             _interface: PhantomData,
@@ -355,11 +357,11 @@ impl<I: Interface> SampleProducerBuilder<I> {
     }
 }
 
-pub struct SampleConsumerDescriptor<I: Interface> {
+pub struct LolaConsumerDescriptor<I: InterfaceConcept> {
     _interface: PhantomData<I>,
 }
 
-impl<I: Interface> Clone for SampleConsumerDescriptor<I> {
+impl<I: InterfaceConcept> Clone for LolaConsumerDescriptor<I> {
     fn clone(&self) -> Self {
         Self {
             _interface: PhantomData,
@@ -367,39 +369,39 @@ impl<I: Interface> Clone for SampleConsumerDescriptor<I> {
     }
 }
 
-pub struct SampleConsumerBuilder<I: Interface> {
+pub struct LolaConsumerBuilder<I: InterfaceConcept> {
     instance_specifier: InstanceSpecifier,
     _interface: PhantomData<I>,
 }
 
-impl<I: Interface> ConsumerDescriptor<LolaRuntimeImpl> for SampleConsumerBuilder<I> {
+impl<I: InterfaceConcept> ConsumerDescriptorConcept<LolaAdapter> for LolaConsumerBuilder<I> {
     fn get_instance_id(&self) -> usize {
         todo!()
     }
 }
 
-pub struct RuntimeBuilderImpl {}
+pub struct LolaAdapterBuilder {}
 
-impl Builder<LolaRuntimeImpl> for RuntimeBuilderImpl {
-    fn build(self) -> com_api_concept::Result<LolaRuntimeImpl> {
-        Ok(LolaRuntimeImpl {})
+impl BuilderConcept<LolaAdapter> for LolaAdapterBuilder {
+    fn build(self) -> com_api_concept::Result<LolaAdapter> {
+        Ok(LolaAdapter {})
     }
 }
 
 /// Entry point for the default implementation for the com module of s-core
-impl com_api_concept::RuntimeBuilder<LolaRuntimeImpl> for RuntimeBuilderImpl {
+impl com_api_concept::AdapterBuilderConcept<LolaAdapter> for LolaAdapterBuilder {
     fn load_config(&mut self, _config: &Path) -> &mut Self {
         self
     }
 }
 
-impl Default for RuntimeBuilderImpl {
+impl Default for LolaAdapterBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RuntimeBuilderImpl {
+impl LolaAdapterBuilder {
     /// Creates a new instance of the default implementation of the com layer
     pub fn new() -> Self {
         Self {}
@@ -408,11 +410,11 @@ impl RuntimeBuilderImpl {
 
 #[cfg(test)]
 mod test {
-    use com_api_concept::{SampleContainer, Subscription};
+    use com_api_concept::{SampleContainer, SubscriptionConcept};
 
     #[test]
     fn receive_stuff() {
-        let test_subscriber = super::SubscriberImpl::<u32>::new();
+        let test_subscriber = super::LolaSubscriber::<u32>::new();
         for _ in 0..10 {
             let mut sample_buf = SampleContainer::new();
             let receive_result = test_subscriber.try_receive(&mut sample_buf, 1);
@@ -432,7 +434,7 @@ mod test {
 
     #[test]
     fn receive_async_stuff() {
-        let test_subscriber = super::SubscriberImpl::<u32>::new();
+        let test_subscriber = super::LolaSubscriber::<u32>::new();
         // block on an asynchronous reception of data from test_subscriber
         futures::executor::block_on(async {
             let mut sample_buf = SampleContainer::new();

--- a/com-api/com-api-runtime-mock/src/lib.rs
+++ b/com-api/com-api-runtime-mock/src/lib.rs
@@ -25,33 +25,35 @@ use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 
 use com_api_concept::{
-    Builder, ConsumerBuilder, ConsumerDescriptor, InstanceSpecifier, Interface, Reloc, Runtime,
-    SampleContainer, ServiceDiscovery, Subscriber, Subscription,
+    AdapterConcept, BuilderConcept, ConsumerBuilderConcept, ConsumerDescriptorConcept,
+    InstanceSpecifier, InterfaceConcept, Reloc, SampleConcept, SampleContainer,
+    SampleMaybeUninitConcept, SampleMutConcept, ServiceDiscoveryConcept, SubscriberConcept,
+    SubscriptionConcept,
 };
 
-pub struct MockRuntimeImpl {}
+pub struct MockAdapter {}
 
-impl Runtime for MockRuntimeImpl {
-    type Sample<'a, T: Reloc + Send + 'a + std::fmt::Debug> = Sample<'a, T>;
+impl AdapterConcept for MockAdapter {
+    type Sample<'a, T: Reloc + Send + 'a + std::fmt::Debug> = MockSample<'a, T>;
 }
 
-impl MockRuntimeImpl {
+impl MockAdapter {
     // TODO: Any chance that these can be moved to a trait so that this becomes more testable?
     // If yes, this trait is certainly located here since
-    pub fn find_service<I: Interface>(
+    pub fn find_service<I: InterfaceConcept>(
         &self,
         _instance_specifier: InstanceSpecifier,
-    ) -> SampleConsumerDiscovery<I> {
-        SampleConsumerDiscovery {
+    ) -> MockConsumerDiscovery<I> {
+        MockConsumerDiscovery {
             _interface: PhantomData,
         }
     }
 
-    pub fn producer_builder<I: Interface>(
+    pub fn producer_builder<I: InterfaceConcept>(
         &self,
         instance_specifier: InstanceSpecifier,
-    ) -> SampleProducerBuilder<I> {
-        SampleProducerBuilder::new(self, instance_specifier)
+    ) -> MockProducerBuilder<I> {
+        MockProducerBuilder::new(self, instance_specifier)
     }
 }
 
@@ -77,7 +79,7 @@ where
     Test(Box<T>),
 }
 
-pub struct Sample<'a, T>
+pub struct MockSample<'a, T>
 where
     T: Reloc + Send,
 {
@@ -87,7 +89,7 @@ where
 
 static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-impl<'a, T> From<T> for Sample<'a, T>
+impl<'a, T> From<T> for MockSample<'a, T>
 where
     T: Reloc + Send,
 {
@@ -99,7 +101,7 @@ where
     }
 }
 
-impl<'a, T> Deref for Sample<'a, T>
+impl<'a, T> Deref for MockSample<'a, T>
 where
     T: Reloc + Send,
 {
@@ -113,9 +115,9 @@ where
     }
 }
 
-impl<'a, T> com_api_concept::Sample<T> for Sample<'a, T> where T: Send + Reloc {}
+impl<'a, T> SampleConcept<T> for MockSample<'a, T> where T: Send + Reloc {}
 
-impl<'a, T> PartialEq for Sample<'a, T>
+impl<'a, T> PartialEq for MockSample<'a, T>
 where
     T: Send + Reloc,
 {
@@ -124,9 +126,9 @@ where
     }
 }
 
-impl<'a, T> Eq for Sample<'a, T> where T: Send + Reloc {}
+impl<'a, T> Eq for MockSample<'a, T> where T: Send + Reloc {}
 
-impl<'a, T> PartialOrd for Sample<'a, T>
+impl<'a, T> PartialOrd for MockSample<'a, T>
 where
     T: Send + Reloc,
 {
@@ -135,7 +137,7 @@ where
     }
 }
 
-impl<'a, T> Ord for Sample<'a, T>
+impl<'a, T> Ord for MockSample<'a, T>
 where
     T: Send + Reloc,
 {
@@ -144,7 +146,7 @@ where
     }
 }
 
-pub struct SampleMut<'a, T>
+pub struct MockSampleMut<'a, T>
 where
     T: Reloc,
 {
@@ -152,11 +154,11 @@ where
     _lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> com_api_concept::SampleMut<T> for SampleMut<'a, T>
+impl<'a, T> SampleMutConcept<T> for MockSampleMut<'a, T>
 where
     T: Reloc + Send,
 {
-    type Sample = Sample<'a, T>;
+    type Sample = MockSample<'a, T>;
 
     fn into_sample(self) -> Self::Sample {
         todo!()
@@ -167,7 +169,7 @@ where
     }
 }
 
-impl<'a, T> Deref for SampleMut<'a, T>
+impl<'a, T> Deref for MockSampleMut<'a, T>
 where
     T: Reloc,
 {
@@ -178,7 +180,7 @@ where
     }
 }
 
-impl<'a, T> DerefMut for SampleMut<'a, T>
+impl<'a, T> DerefMut for MockSampleMut<'a, T>
 where
     T: Reloc,
 {
@@ -187,7 +189,7 @@ where
     }
 }
 
-pub struct SampleMaybeUninit<'a, T>
+pub struct MockSampleMaybeUninit<'a, T>
 where
     T: Reloc + Send,
 {
@@ -195,54 +197,54 @@ where
     _lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> com_api_concept::SampleMaybeUninit<T> for SampleMaybeUninit<'a, T>
+impl<'a, T> SampleMaybeUninitConcept<T> for MockSampleMaybeUninit<'a, T>
 where
     T: Reloc + Send,
 {
-    type SampleMut = SampleMut<'a, T>;
+    type SampleMut = MockSampleMut<'a, T>;
 
-    fn write(self, val: T) -> SampleMut<'a, T> {
-        SampleMut {
+    fn write(self, val: T) -> Self::SampleMut {
+        Self::SampleMut {
             data: val,
             _lifetime: PhantomData,
         }
     }
 
-    unsafe fn assume_init(self) -> SampleMut<'a, T> { 
-        SampleMut {
+    unsafe fn assume_init(self) -> Self::SampleMut {
+        Self::SampleMut {
             data: unsafe { self.data.assume_init() },
             _lifetime: PhantomData,
         }
     }
 }
 
-pub struct SubscribableImpl<T> {
+pub struct MockSubscribable<T> {
     _data: PhantomData<T>,
 }
 
-impl<T> Default for SubscribableImpl<T> {
+impl<T> Default for MockSubscribable<T> {
     fn default() -> Self {
         Self { _data: PhantomData }
     }
 }
 
-impl<T: Reloc + Send> Subscriber<T> for SubscribableImpl<T> {
-    type Subscription = SubscriberImpl<T>;
+impl<T: Reloc + Send> SubscriberConcept<T> for MockSubscribable<T> {
+    type Subscription = MockSubscriber<T>;
 
     fn subscribe(self, _max_num_samples: usize) -> com_api_concept::Result<Self::Subscription> {
-        Ok(SubscriberImpl::new())
+        Ok(MockSubscriber::new())
     }
 }
 
 #[derive(Default)]
-pub struct SubscriberImpl<T>
+pub struct MockSubscriber<T>
 where
     T: Reloc + Send,
 {
     data: VecDeque<T>,
 }
 
-impl<T> SubscriberImpl<T>
+impl<T> MockSubscriber<T>
 where
     T: Reloc + Send,
 {
@@ -257,13 +259,13 @@ where
     }
 }
 
-impl<T> Subscription<T> for SubscriberImpl<T>
+impl<T> SubscriptionConcept<T> for MockSubscriber<T>
 where
     T: Reloc + Send,
 {
-    type Subscriber = SubscribableImpl<T>;
+    type Subscriber = MockSubscribable<T>;
     type Sample<'a>
-        = Sample<'a, T>
+        = MockSample<'a, T>
     where
         T: 'a;
 
@@ -290,11 +292,11 @@ where
     }
 }
 
-pub struct Publisher<T> {
+pub struct MockPublisher<T> {
     _data: PhantomData<T>,
 }
 
-impl<T> Default for Publisher<T>
+impl<T> Default for MockPublisher<T>
 where
     T: Reloc + Send,
 {
@@ -303,7 +305,7 @@ where
     }
 }
 
-impl<T> Publisher<T>
+impl<T> MockPublisher<T>
 where
     T: Reloc + Send,
 {
@@ -311,45 +313,45 @@ where
         Self { _data: PhantomData }
     }
 
-    pub fn allocate<'a>(&'a self) -> com_api_concept::Result<SampleMaybeUninit<'a, T>> {
-        Ok(SampleMaybeUninit {
+    pub fn allocate<'a>(&'a self) -> com_api_concept::Result<MockSampleMaybeUninit<'a, T>> {
+        Ok(MockSampleMaybeUninit {
             data: MaybeUninit::uninit(),
             _lifetime: PhantomData,
         })
     }
 }
 
-pub struct SampleConsumerDiscovery<I> {
+pub struct MockConsumerDiscovery<I> {
     _interface: PhantomData<I>,
 }
 
-impl<I> SampleConsumerDiscovery<I> {
-    fn new(_runtime: &MockRuntimeImpl, _instance_specifier: InstanceSpecifier) -> Self {
+impl<I> MockConsumerDiscovery<I> {
+    fn new(_runtime: &MockAdapter, _instance_specifier: InstanceSpecifier) -> Self {
         Self {
             _interface: PhantomData,
         }
     }
 }
 
-impl<I: Interface> ServiceDiscovery<I, MockRuntimeImpl> for SampleConsumerDiscovery<I>
+impl<I: InterfaceConcept> ServiceDiscoveryConcept<I, MockAdapter> for MockConsumerDiscovery<I>
 where
-    SampleConsumerBuilder<I>: ConsumerBuilder<I, MockRuntimeImpl>,
+    MockConsumerBuilder<I>: ConsumerBuilderConcept<I, MockAdapter>,
 {
-    type ConsumerBuilder = SampleConsumerBuilder<I>;
-    type ServiceEnumerator = Vec<SampleConsumerBuilder<I>>;
+    type ConsumerBuilder = MockConsumerBuilder<I>;
+    type ServiceEnumerator = Vec<MockConsumerBuilder<I>>;
 
     fn get_available_instances(&self) -> com_api_concept::Result<Self::ServiceEnumerator> {
         Ok(Vec::new())
     }
 }
 
-pub struct SampleProducerBuilder<I: Interface> {
+pub struct MockProducerBuilder<I: InterfaceConcept> {
     instance_specifier: InstanceSpecifier,
     _interface: PhantomData<I>,
 }
 
-impl<I: Interface> SampleProducerBuilder<I> {
-    fn new(_runtime: &MockRuntimeImpl, instance_specifier: InstanceSpecifier) -> Self {
+impl<I: InterfaceConcept> MockProducerBuilder<I> {
+    fn new(_runtime: &MockAdapter, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
             _interface: PhantomData,
@@ -357,11 +359,11 @@ impl<I: Interface> SampleProducerBuilder<I> {
     }
 }
 
-pub struct SampleConsumerDescriptor<I: Interface> {
+pub struct MockConsumerDescriptor<I: InterfaceConcept> {
     _interface: PhantomData<I>,
 }
 
-impl<I: Interface> Clone for SampleConsumerDescriptor<I> {
+impl<I: InterfaceConcept> Clone for MockConsumerDescriptor<I> {
     fn clone(&self) -> Self {
         Self {
             _interface: PhantomData,
@@ -369,39 +371,39 @@ impl<I: Interface> Clone for SampleConsumerDescriptor<I> {
     }
 }
 
-pub struct SampleConsumerBuilder<I: Interface> {
+pub struct MockConsumerBuilder<I: InterfaceConcept> {
     instance_specifier: InstanceSpecifier,
     _interface: PhantomData<I>,
 }
 
-impl<I: Interface> ConsumerDescriptor<MockRuntimeImpl> for SampleConsumerBuilder<I> {
+impl<I: InterfaceConcept> ConsumerDescriptorConcept<MockAdapter> for MockConsumerBuilder<I> {
     fn get_instance_id(&self) -> usize {
         todo!()
     }
 }
 
-pub struct RuntimeBuilderImpl {}
+pub struct MockAdapterBuilder {}
 
-impl Builder<MockRuntimeImpl> for RuntimeBuilderImpl {
-    fn build(self) -> com_api_concept::Result<MockRuntimeImpl> {
-        Ok(MockRuntimeImpl {})
+impl BuilderConcept<MockAdapter> for MockAdapterBuilder {
+    fn build(self) -> com_api_concept::Result<MockAdapter> {
+        Ok(MockAdapter {})
     }
 }
 
 /// Entry point for the default implementation for the com module of s-core
-impl com_api_concept::RuntimeBuilder<MockRuntimeImpl> for RuntimeBuilderImpl {
+impl com_api_concept::AdapterBuilderConcept<MockAdapter> for MockAdapterBuilder {
     fn load_config(&mut self, _config: &Path) -> &mut Self {
         self
     }
 }
 
-impl Default for RuntimeBuilderImpl {
+impl Default for MockAdapterBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RuntimeBuilderImpl {
+impl MockAdapterBuilder {
     /// Creates a new instance of the default implementation of the com layer
     pub fn new() -> Self {
         Self {}
@@ -410,11 +412,11 @@ impl RuntimeBuilderImpl {
 
 #[cfg(test)]
 mod test {
-    use com_api_concept::{SampleContainer, Subscription};
+    use com_api_concept::{SampleContainer, SubscriptionConcept};
 
     #[test]
     fn receive_stuff() {
-        let test_subscriber = super::SubscriberImpl::<u32>::new();
+        let test_subscriber = super::MockSubscriber::<u32>::new();
         for _ in 0..10 {
             let mut sample_buf = SampleContainer::new();
             let receive_result = test_subscriber.try_receive(&mut sample_buf, 1);
@@ -434,7 +436,7 @@ mod test {
 
     #[test]
     fn receive_async_stuff() {
-        let test_subscriber = super::SubscriberImpl::<u32>::new();
+        let test_subscriber = super::MockSubscriber::<u32>::new();
         // block on an asynchronous reception of data from test_subscriber
         futures::executor::block_on(async {
             let mut sample_buf = SampleContainer::new();

--- a/com-api/com-api/src/lib.rs
+++ b/com-api/com-api/src/lib.rs
@@ -14,21 +14,21 @@
 //! The actual implementations are provided by the `com-api-runtime-mock` and `com-api-runtime-lola` crates.
 //! The user must enable one of these features to use the COM API.
 
-
 #[cfg(not(any(feature = "mock", feature = "lola")))]
 compile_error!("You must enable at least one feature: `mock` or `lola`!");
 
-#[cfg(feature = "mock")]
-pub use com_api_runtime_mock::RuntimeBuilderImpl;
-#[cfg(feature = "mock")]
-pub use com_api_runtime_mock::MockRuntimeImpl;
 #[cfg(feature = "lola")]
-pub use com_api_runtime_lola::RuntimeBuilderImpl;
+pub use com_api_runtime_lola::LolaAdapter;
 #[cfg(feature = "lola")]
-pub use com_api_runtime_lola::LolaRuntimeImpl;
+pub use com_api_runtime_lola::LolaAdapterBuilder;
+#[cfg(feature = "mock")]
+pub use com_api_runtime_mock::MockAdapter;
+#[cfg(feature = "mock")]
+pub use com_api_runtime_mock::MockAdapterBuilder;
 
 pub use com_api_concept::{
-    Builder, Consumer, ConsumerBuilder, ConsumerDescriptor, InstanceSpecifier, Interface,
-    OfferedProducer, Producer, ProducerBuilder, Reloc, Result, SampleContainer, SampleMaybeUninit,
-    SampleMut, ServiceDiscovery, Subscriber, Subscription,
+    BuilderConcept, ConsumerBuilderConcept, ConsumerConcept, ConsumerDescriptorConcept,
+    InstanceSpecifier, InterfaceConcept, OfferedProducerConcept, ProducerBuilderConcept,
+    ProducerConcept, Reloc, Result, SampleConcept, SampleContainer, SampleMaybeUninitConcept,
+    SampleMutConcept, ServiceDiscoveryConcept, SubscriberConcept, SubscriptionConcept,
 };

--- a/com-api/examples/basic-consumer-producer.rs
+++ b/com-api/examples/basic-consumer-producer.rs
@@ -13,8 +13,14 @@ use com_api::*;
 use com_api_gen::*;
 
 fn main() {
-    let runtime_builder = RuntimeBuilderImpl::new();
-    let runtime = Builder::<MockRuntimeImpl>::build(runtime_builder).unwrap();
+    #[cfg(feature = "mock")]
+    let runtime_builder = MockAdapterBuilder::new();
+    #[cfg(feature = "mock")]
+    let runtime = BuilderConcept::<MockAdapter>::build(runtime_builder).unwrap();
+    #[cfg(feature = "lola")]
+    let runtime_builder = LolaAdapterBuilder::new();
+    #[cfg(feature = "lola")]
+    let runtime = BuilderConcept::<LolaAdapter>::build(runtime_builder).unwrap();
     let producer_builder = runtime.producer_builder::<VehicleInterface>(InstanceSpecifier {
         specifier: "My/Funk/ServiceName".to_string(),
     });
@@ -66,7 +72,7 @@ mod test {
     #[test]
     fn create_producer() {
         // Factory
-        let runtime_builder = RuntimeBuilderImpl::new();
+        let runtime_builder = AdapterBuilder::new();
         let runtime = runtime_builder.build().unwrap();
         let producer_builder = runtime.producer_builder::<VehicleInterface>(InstanceSpecifier {
             specifier: "My/Funk/ServiceName".to_string(),
@@ -83,7 +89,7 @@ mod test {
     #[test]
     fn create_consumer() {
         // Create runtime
-        let runtime_builder = RuntimeBuilderImpl::new();
+        let runtime_builder = AdapterBuilder::new();
         let runtime = runtime_builder.build().unwrap();
 
         // Create service discovery
@@ -116,7 +122,7 @@ mod test {
         }
     }
 
-    async fn async_data_processor_fn(subscribed: impl Subscription<Tire>) {
+    async fn async_data_processor_fn(subscribed: impl SubscriptionConcept<Tire>) {
         let mut buffer = SampleContainer::new();
         for _ in 0..10 {
             match subscribed.receive(&mut buffer, 1, 1).await {
@@ -135,7 +141,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn schedule_subscription_on_mt_scheduler() {
-        let runtime_builder = RuntimeBuilderImpl::new();
+        let runtime_builder = AdapterBuilder::new();
         let runtime = runtime_builder.build().unwrap();
 
         let consumer_discovery = runtime.find_service::<VehicleInterface>(InstanceSpecifier {

--- a/com-api/examples/com-api-gen/com-api-gen-lola/src/lib.rs
+++ b/com-api/examples/com-api-gen/com-api-gen-lola/src/lib.rs
@@ -23,7 +23,9 @@
 //! ```
 
 use com_api::*;
-use com_api_runtime_lola::{LolaRuntimeImpl, SampleConsumerBuilder, SampleProducerBuilder};
+use com_api_runtime_lola::{
+    LolaAdapter, LolaConsumerBuilder, LolaProducerBuilder, LolaPublisher, LolaSubscribable,
+};
 
 #[derive(Debug)]
 pub struct Tire {}
@@ -35,15 +37,15 @@ unsafe impl Reloc for Exhaust {}
 pub struct VehicleInterface {}
 
 /// Generic
-impl Interface for VehicleInterface {}
+impl InterfaceConcept for VehicleInterface {}
 
 pub struct AnotherInterface {}
 
-impl Interface for AnotherInterface {}
+impl InterfaceConcept for AnotherInterface {}
 
 pub struct VehicleProducer {}
 
-impl Producer for VehicleProducer {
+impl ProducerConcept for VehicleProducer {
     type Interface = VehicleInterface;
     type OfferedProducer = VehicleOfferedProducer;
 
@@ -53,11 +55,11 @@ impl Producer for VehicleProducer {
 }
 
 pub struct VehicleOfferedProducer {
-    pub left_tire: com_api_runtime_lola::Publisher<Tire>,
-    pub exhaust: com_api_runtime_lola::Publisher<Exhaust>,
+    pub left_tire: LolaPublisher<Tire>,
+    pub exhaust: LolaPublisher<Exhaust>,
 }
 
-impl OfferedProducer for VehicleOfferedProducer {
+impl OfferedProducerConcept for VehicleOfferedProducer {
     type Interface = VehicleInterface;
     type Producer = VehicleProducer;
 
@@ -66,27 +68,30 @@ impl OfferedProducer for VehicleOfferedProducer {
     }
 }
 
-impl Builder<VehicleProducer> for SampleProducerBuilder<VehicleInterface> {
+impl BuilderConcept<VehicleProducer> for LolaProducerBuilder<VehicleInterface> {
     fn build(self) -> com_api::Result<VehicleProducer> {
         todo!()
     }
 }
 
-impl ProducerBuilder<VehicleInterface, LolaRuntimeImpl, VehicleProducer>
-    for SampleProducerBuilder<VehicleInterface>
+impl ProducerBuilderConcept<VehicleInterface, LolaAdapter, VehicleProducer>
+    for LolaProducerBuilder<VehicleInterface>
 {
 }
 
 pub struct VehicleConsumer {
-    pub left_tire: com_api_runtime_lola::SubscribableImpl<Tire>,
-    pub exhaust: com_api_runtime_lola::SubscribableImpl<Exhaust>,
+    pub left_tire: LolaSubscribable<Tire>,
+    pub exhaust: LolaSubscribable<Exhaust>,
 }
 
-impl Consumer for VehicleConsumer {}
+impl ConsumerConcept for VehicleConsumer {}
 
-impl ConsumerBuilder<VehicleInterface, LolaRuntimeImpl> for SampleConsumerBuilder<VehicleInterface> {}
+impl ConsumerBuilderConcept<VehicleInterface, LolaAdapter>
+    for LolaConsumerBuilder<VehicleInterface>
+{
+}
 
-impl Builder<VehicleConsumer> for SampleConsumerBuilder<VehicleInterface> {
+impl BuilderConcept<VehicleConsumer> for LolaConsumerBuilder<VehicleInterface> {
     fn build(self) -> com_api::Result<VehicleConsumer> {
         todo!()
     }

--- a/com-api/examples/com-api-gen/com-api-gen-mock/src/lib.rs
+++ b/com-api/examples/com-api-gen/com-api-gen-mock/src/lib.rs
@@ -23,7 +23,9 @@
 //! ```
 
 use com_api::*;
-use com_api_runtime_mock::{MockRuntimeImpl, SampleConsumerBuilder, SampleProducerBuilder};
+use com_api_runtime_mock::{
+    MockAdapter, MockConsumerBuilder, MockProducerBuilder, MockPublisher, MockSubscribable,
+};
 
 #[derive(Debug)]
 pub struct Tire {}
@@ -35,15 +37,15 @@ unsafe impl Reloc for Exhaust {}
 pub struct VehicleInterface {}
 
 /// Generic
-impl Interface for VehicleInterface {}
+impl InterfaceConcept for VehicleInterface {}
 
 pub struct AnotherInterface {}
 
-impl Interface for AnotherInterface {}
+impl InterfaceConcept for AnotherInterface {}
 
 pub struct VehicleProducer {}
 
-impl Producer for VehicleProducer {
+impl ProducerConcept for VehicleProducer {
     type Interface = VehicleInterface;
     type OfferedProducer = VehicleOfferedProducer;
 
@@ -53,11 +55,11 @@ impl Producer for VehicleProducer {
 }
 
 pub struct VehicleOfferedProducer {
-    pub left_tire: com_api_runtime_mock::Publisher<Tire>,
-    pub exhaust: com_api_runtime_mock::Publisher<Exhaust>,
+    pub left_tire: MockPublisher<Tire>,
+    pub exhaust: MockPublisher<Exhaust>,
 }
 
-impl OfferedProducer for VehicleOfferedProducer {
+impl OfferedProducerConcept for VehicleOfferedProducer {
     type Interface = VehicleInterface;
     type Producer = VehicleProducer;
 
@@ -66,27 +68,30 @@ impl OfferedProducer for VehicleOfferedProducer {
     }
 }
 
-impl Builder<VehicleProducer> for SampleProducerBuilder<VehicleInterface> {
+impl BuilderConcept<VehicleProducer> for MockProducerBuilder<VehicleInterface> {
     fn build(self) -> com_api::Result<VehicleProducer> {
         todo!()
     }
 }
 
-impl ProducerBuilder<VehicleInterface, MockRuntimeImpl, VehicleProducer>
-    for SampleProducerBuilder<VehicleInterface>
+impl ProducerBuilderConcept<VehicleInterface, MockAdapter, VehicleProducer>
+    for MockProducerBuilder<VehicleInterface>
 {
 }
 
 pub struct VehicleConsumer {
-    pub left_tire: com_api_runtime_mock::SubscribableImpl<Tire>,
-    pub exhaust: com_api_runtime_mock::SubscribableImpl<Exhaust>,
+    pub left_tire: MockSubscribable<Tire>,
+    pub exhaust: MockSubscribable<Exhaust>,
 }
 
-impl Consumer for VehicleConsumer {}
+impl ConsumerConcept for VehicleConsumer {}
 
-impl ConsumerBuilder<VehicleInterface, MockRuntimeImpl> for SampleConsumerBuilder<VehicleInterface> {}
+impl ConsumerBuilderConcept<VehicleInterface, MockAdapter>
+    for MockConsumerBuilder<VehicleInterface>
+{
+}
 
-impl Builder<VehicleConsumer> for SampleConsumerBuilder<VehicleInterface> {
+impl BuilderConcept<VehicleConsumer> for MockConsumerBuilder<VehicleInterface> {
     fn build(self) -> com_api::Result<VehicleConsumer> {
         todo!()
     }

--- a/com-api/examples/com-api-gen/src/lib.rs
+++ b/com-api/examples/com-api-gen/src/lib.rs
@@ -9,7 +9,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "mock")]
-pub use com_api_gen_mock::{Tire, VehicleInterface};
 #[cfg(feature = "lola")]
 pub use com_api_gen_lola::{Tire, VehicleInterface};
+#[cfg(feature = "mock")]
+pub use com_api_gen_mock::{Tire, VehicleInterface};


### PR DESCRIPTION
This PR contains only renaming of API's contents to improve overall readability.
It is intended to not add any functional changes here which will be provided in further PRs.