### PR TITLE
Introduce placement default

### DIFF
--- a/com-api/com-api-concept/src/lib.rs
+++ b/com-api/com-api-concept/src/lib.rs
@@ -249,10 +249,24 @@ where
     ///
     /// The caller has to make sure to initialize the data in the buffer before calling this method.
     unsafe fn assume_init(self) -> Self::SampleMut;
+
     /// Write a value into the buffer and render it initialized.
     ///
     /// This corresponds to `MaybeUninit::write`.
     fn write(self, value: T) -> Self::SampleMut;
+
+    /// Writes in place (skipping intermediate moves) the default value directly into the buffer and renders it initialized.
+    /// This requires that T implements `PlacementDefault`.
+    fn write_default(mut self) -> Self::SampleMut
+    where
+        Self: Sized,
+        T: PlacementDefault,
+    {
+        T::placement_default(self.as_mut().as_mut_ptr());
+
+        // Safety: `placement_default` initialized the data
+        unsafe { self.assume_init() }
+    }
 }
 
 pub trait Interface {
@@ -439,6 +453,23 @@ pub trait Subscription<T: Reloc + Send + Debug, R: Runtime + ?Sized> {
         new_samples: usize,
         max_samples: usize,
     ) -> impl Future<Output = Result<usize>> + Send;
+}
+
+/// A trait for types that can be default-constructed in place, skipping intermediate moves.
+///
+/// # Safety
+/// The implementer must ensure that the `placement_default` method correctly initializes the
+/// memory at the given pointer to a valid instance of the type, without creating temporary
+/// references that would lead to undefined behavior. The `value` under pointer after call to
+/// `placement_default` is considered initialized.
+pub unsafe trait PlacementDefault: Default {
+    /// Writes in place (skipping intermediate moves) the default value directly into the buffer.
+    ///
+    /// # Safety
+    ///  - `ptr` shall be assumed the pointer to uninitialized memory
+    ///  - implementer shall use `&raw FIELD` access to write data into fields and not producing
+    ///    temporary references that would cause undefined behavior
+    fn placement_default(ptr: *mut Self);
 }
 
 mod tests {

--- a/com-api/com-api/src/lib.rs
+++ b/com-api/com-api/src/lib.rs
@@ -20,7 +20,7 @@ pub use com_api_runtime_mock::RuntimeBuilderImpl as MockRuntimeBuilderImpl;
 
 pub use com_api_concept::{
     Builder, Consumer, ConsumerBuilder, ConsumerDescriptor, Error, FindServiceSpecifier,
-    InstanceSpecifier, Interface, OfferedProducer, Producer, ProducerBuilder, Publisher, Reloc,
-    Result, Runtime, SampleContainer, SampleMaybeUninit, SampleMut, ServiceDiscovery, Subscriber,
-    Subscription,
+    InstanceSpecifier, Interface, OfferedProducer, PlacementDefault, Producer, ProducerBuilder,
+    Publisher, Reloc, Result, Runtime, SampleContainer, SampleMaybeUninit, SampleMut,
+    ServiceDiscovery, Subscriber, Subscription,
 };

--- a/com-api/examples/basic-consumer-producer.rs
+++ b/com-api/examples/basic-consumer-producer.rs
@@ -83,7 +83,7 @@ fn run_with_runtime<R: Runtime>(name: &str, runtime: &R) {
     let monitor = VehicleMonitor::new(consumer, producer);
 
     for _ in 0..5 {
-        monitor.write_tire_data(Tire {}).unwrap();
+        monitor.write_tire_data(Tire::default()).unwrap();
         let tire_data = monitor.read_tire_data().unwrap();
         println!("{}", tire_data);
     }

--- a/com-api/examples/com-api-gen/src/lib.rs
+++ b/com-api/examples/com-api-gen/src/lib.rs
@@ -23,12 +23,25 @@
 //! ```
 
 use com_api::{
-    Consumer, Interface, OfferedProducer, Producer, Publisher, Reloc, Runtime, Subscriber,
+    Consumer, Interface, OfferedProducer, PlacementDefault, Producer, Publisher, Reloc, Runtime,
+    Subscriber,
 };
 
-#[derive(Debug)]
-pub struct Tire {}
+#[derive(Debug, Default)]
+pub struct Tire {
+    pub pressure: f32,
+}
 unsafe impl Reloc for Tire {}
+
+unsafe impl PlacementDefault for Tire {
+    fn placement_default(ptr: *mut Self) {
+        // For demonstration purposes, we just use the Default implementation.
+        unsafe {
+            let pressure = &raw mut (*ptr).pressure;
+            pressure.write(12.0);
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Exhaust {}


### PR DESCRIPTION
Intoroduce default way of implementing
initilization of data in place (in previously
allocated memory)